### PR TITLE
Fix JUnit report rewriting (preserve formatting).

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
 
   <properties>
     <maven.version>3.0.1</maven.version>
-    <woodstox.version>5.0.2</woodstox.version>
     <junit.version>4.10</junit.version>
     <mockito.version>1.10.19</mockito.version>
     <commons.io.version>2.4</commons.io.version>
@@ -30,7 +29,6 @@
     <maven.compiler.target>1.7</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.shared.utils.version>3.0.0</maven.shared.utils.version>
-    <jdom.version>2.0.2</jdom.version>
   </properties>
 
   <developers>
@@ -67,16 +65,6 @@
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-shared-utils</artifactId>
       <version>${maven.shared.utils.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.woodstox</groupId>
-      <artifactId>woodstox-core</artifactId>
-      <version>${woodstox.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jdom</groupId>
-      <artifactId>jdom</artifactId>
-      <version>${jdom.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/com/stratio/mojo/scala/crossbuild/FileRewriter.java
+++ b/src/main/java/com/stratio/mojo/scala/crossbuild/FileRewriter.java
@@ -39,7 +39,7 @@ class FileRewriter {
     this.rules = rules;
   }
 
-  public void rewrite(final File file) throws IOException, XMLStreamException {
+  public void rewrite(final File file) throws IOException {
     if (!file.exists()) {
       throw new FileNotFoundException("File does not exist: " + file);
     }

--- a/src/main/java/com/stratio/mojo/scala/crossbuild/JUnitReportRewriteRule.java
+++ b/src/main/java/com/stratio/mojo/scala/crossbuild/JUnitReportRewriteRule.java
@@ -1,0 +1,35 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.mojo.scala.crossbuild;
+
+import java.util.regex.Pattern;
+
+class JUnitReportRewriteRule extends RegexRewriteRule {
+
+  private final static Pattern artifactIdPattern = Pattern.compile(
+      "(<testcase.*?\\s+name=\"[^\"]*?)(?:\\s+\\[Scala\\s\\d+\\.\\d+\\])?(\".*)"
+  );
+  private final static Pattern limitPattern = Pattern.compile("</testsuite>");
+
+  public JUnitReportRewriteRule(final String newVersion) {
+    super(
+        artifactIdPattern,
+        "$1 [Scala " + newVersion + "]$2",
+        limitPattern
+    );
+  }
+
+}

--- a/src/main/java/com/stratio/mojo/scala/crossbuild/TransformJUnitReportMojo.java
+++ b/src/main/java/com/stratio/mojo/scala/crossbuild/TransformJUnitReportMojo.java
@@ -23,7 +23,6 @@ import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
 import org.apache.maven.shared.utils.io.DirectoryScanner;
-import org.jdom2.JDOMException;
 
 /**
  * Transforms JUnit XML reports so that Scala binary version
@@ -51,7 +50,7 @@ public class TransformJUnitReportMojo extends AbstractCrossBuildMojo {
     for (final String file: getAllFiles(includes, excludes)) {
       try {
         rewriter.rewrite(new File(file), scalaBinaryVersion);
-      } catch (final IOException | JDOMException ex) {
+      } catch (final IOException ex) {
         throw new MojoFailureException("Error while rewriting", ex);
       }
     }

--- a/src/test/resources/TEST-com.stratio.common.utils.components.repository.RepositoryComponentTest.xml
+++ b/src/test/resources/TEST-com.stratio.common.utils.components.repository.RepositoryComponentTest.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0" tests="16" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.runtime.name" value="OpenJDK Runtime Environment"/>
+    <property name="sun.boot.library.path" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64"/>
+    <property name="java.vm.version" value="25.45-b02"/>
+    <property name="java.vm.vendor" value="Oracle Corporation"/>
+    <property name="java.vendor.url" value="http://java.oracle.com/"/>
+    <property name="path.separator" value=":"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="file.encoding.pkg" value="sun.io"/>
+    <property name="user.country" value="US"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="sun.os.patch.level" value="unknown"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="user.dir" value="/root/workspace/Common-utils/cuP33"/>
+    <property name="java.runtime.version" value="1.8.0_45-internal-b14"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.X11GraphicsEnvironment"/>
+    <property name="java.endorsed.dirs" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/endorsed"/>
+    <property name="os.arch" value="amd64"/>
+    <property name="java.io.tmpdir" value="/tmp"/>
+    <property name="line.separator" value="
+"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="os.name" value="Linux"/>
+    <property name="classworlds.conf" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5/bin/m2.conf"/>
+    <property name="sun.jnu.encoding" value="ANSI_X3.4-1968"/>
+    <property name="java.library.path" value="/usr/java/packages/lib/amd64:/usr/lib/x86_64-linux-gnu/jni:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/jni:/lib:/usr/lib"/>
+    <property name="license.skip" value="true"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.class.version" value="52.0"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="3.19.0-47-generic"/>
+    <property name="user.home" value="/root"/>
+    <property name="user.timezone" value="Etc/UTC"/>
+    <property name="java.awt.printerjob" value="sun.print.PSPrinterJob"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.specification.version" value="1.8"/>
+    <property name="user.name" value="root"/>
+    <property name="java.class.path" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5/boot/plexus-classworlds-2.5.2.jar"/>
+    <property name="java.vm.specification.version" value="1.8"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="java.home" value="/usr/lib/jvm/java-8-openjdk-amd64/jre"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher -B -T 0.5C -Dlicense.skip test"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.language" value="en"/>
+    <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="1.8.0_45-internal"/>
+    <property name="java.ext.dirs" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext:/usr/java/packages/lib/ext"/>
+    <property name="securerandom.source" value="file:/dev/./urandom"/>
+    <property name="sun.boot.class.path" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/resources.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jce.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jfr.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/classes"/>
+    <property name="java.vendor" value="Oracle Corporation"/>
+    <property name="maven.home" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+    <property name="sun.cpu.isalist" value=""/>
+  </properties>
+  <testcase name="A repository component when get an element should return an option with the value if the key exists" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when get an element should return None if the key doesn't exist" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getAll elements should return all elements if the operation is successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getAll elements should return and empty list if the operation is not successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getNodes elements should return all nodes if the operation is successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getNodes elements should return and empty list if the operation is not successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when check if a value exists should return true if the value exists" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when check if a value exists should return false if the value doesn't exist" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when create a new value should return true if the operation is successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when create a new value should return false if the operation is not successful" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove a value should check that the element does not exist when it has been removed" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove a value should do anything when a not existing element is removed" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove all values should check that the element does not exist when it has been removed all" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove all values should do anything when a not existing element is removed all" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when update a value should check that the element has been updated with the new value" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when update a value should do anything when a not existing element is updated" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+</testsuite>

--- a/src/test/resources/TEST-com.stratio.common.utils.components.repository.RepositoryComponentTest_result.xml
+++ b/src/test/resources/TEST-com.stratio.common.utils.components.repository.RepositoryComponentTest_result.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0" tests="16" errors="0" skipped="0" failures="0">
+  <properties>
+    <property name="java.runtime.name" value="OpenJDK Runtime Environment"/>
+    <property name="sun.boot.library.path" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/amd64"/>
+    <property name="java.vm.version" value="25.45-b02"/>
+    <property name="java.vm.vendor" value="Oracle Corporation"/>
+    <property name="java.vendor.url" value="http://java.oracle.com/"/>
+    <property name="path.separator" value=":"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="java.vm.name" value="OpenJDK 64-Bit Server VM"/>
+    <property name="file.encoding.pkg" value="sun.io"/>
+    <property name="user.country" value="US"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="sun.os.patch.level" value="unknown"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="user.dir" value="/root/workspace/Common-utils/cuP33"/>
+    <property name="java.runtime.version" value="1.8.0_45-internal-b14"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.X11GraphicsEnvironment"/>
+    <property name="java.endorsed.dirs" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/endorsed"/>
+    <property name="os.arch" value="amd64"/>
+    <property name="java.io.tmpdir" value="/tmp"/>
+    <property name="line.separator" value="
+"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="os.name" value="Linux"/>
+    <property name="classworlds.conf" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5/bin/m2.conf"/>
+    <property name="sun.jnu.encoding" value="ANSI_X3.4-1968"/>
+    <property name="java.library.path" value="/usr/java/packages/lib/amd64:/usr/lib/x86_64-linux-gnu/jni:/lib/x86_64-linux-gnu:/usr/lib/x86_64-linux-gnu:/usr/lib/jni:/lib:/usr/lib"/>
+    <property name="license.skip" value="true"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.class.version" value="52.0"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="3.19.0-47-generic"/>
+    <property name="user.home" value="/root"/>
+    <property name="user.timezone" value="Etc/UTC"/>
+    <property name="java.awt.printerjob" value="sun.print.PSPrinterJob"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.specification.version" value="1.8"/>
+    <property name="user.name" value="root"/>
+    <property name="java.class.path" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5/boot/plexus-classworlds-2.5.2.jar"/>
+    <property name="java.vm.specification.version" value="1.8"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="java.home" value="/usr/lib/jvm/java-8-openjdk-amd64/jre"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher -B -T 0.5C -Dlicense.skip test"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.language" value="en"/>
+    <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="1.8.0_45-internal"/>
+    <property name="java.ext.dirs" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/ext:/usr/java/packages/lib/ext"/>
+    <property name="securerandom.source" value="file:/dev/./urandom"/>
+    <property name="sun.boot.class.path" value="/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/resources.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/rt.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jsse.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jce.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/charsets.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/lib/jfr.jar:/usr/lib/jvm/java-8-openjdk-amd64/jre/classes"/>
+    <property name="java.vendor" value="Oracle Corporation"/>
+    <property name="maven.home" value="/root/tools/hudson.tasks.Maven_MavenInstallation/Maven-3.2.5"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+    <property name="sun.cpu.isalist" value=""/>
+  </properties>
+  <testcase name="A repository component when get an element should return an option with the value if the key exists [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when get an element should return None if the key doesn't exist [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getAll elements should return all elements if the operation is successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getAll elements should return and empty list if the operation is not successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getNodes elements should return all nodes if the operation is successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when getNodes elements should return and empty list if the operation is not successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when check if a value exists should return true if the value exists [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when check if a value exists should return false if the value doesn't exist [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when create a new value should return true if the operation is successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when create a new value should return false if the operation is not successful [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove a value should check that the element does not exist when it has been removed [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove a value should do anything when a not existing element is removed [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove all values should check that the element does not exist when it has been removed all [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when remove all values should do anything when a not existing element is removed all [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when update a value should check that the element has been updated with the new value [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+  <testcase name="A repository component when update a value should do anything when a not existing element is updated [Scala 2.11]" classname="com.stratio.common.utils.components.repository.RepositoryComponentTest" time="0"/>
+</testsuite>

--- a/src/test/resources/basic_junit.xml
+++ b/src/test/resources/basic_junit.xml
@@ -56,6 +56,6 @@
   </properties>
   <testcase name="replacement" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.035"/>
   <testcase name="noStartDocument" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.001"/>
-  <testcase name="badPath" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002"/>
+  <testcase name="badPath [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002"/>
   <testcase classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002" name="noArtifactChange" />
 </testsuite>

--- a/src/test/resources/basic_junit_result.xml
+++ b/src/test/resources/basic_junit_result.xml
@@ -1,61 +1,61 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.04" tests="4" errors="0" skipped="0" failures="0">
   <properties>
-    <property name="java.runtime.name" value="Java(TM) SE Runtime Environment" />
-    <property name="sun.boot.library.path" value="/usr/lib/jvm/java-7-oracle/jre/lib/amd64" />
-    <property name="java.vm.version" value="24.80-b11" />
-    <property name="java.vm.vendor" value="Oracle Corporation" />
-    <property name="java.vendor.url" value="http://java.oracle.com/" />
-    <property name="path.separator" value=":" />
-    <property name="guice.disable.misplaced.annotation.check" value="true" />
-    <property name="java.vm.name" value="Java HotSpot(TM) 64-Bit Server VM" />
-    <property name="file.encoding.pkg" value="sun.io" />
-    <property name="user.country" value="GB" />
-    <property name="sun.java.launcher" value="SUN_STANDARD" />
-    <property name="sun.os.patch.level" value="unknown" />
-    <property name="java.vm.specification.name" value="Java Virtual Machine Specification" />
-    <property name="java.runtime.version" value="1.7.0_80-b15" />
-    <property name="java.awt.graphicsenv" value="sun.awt.X11GraphicsEnvironment" />
-    <property name="java.endorsed.dirs" value="/usr/lib/jvm/java-7-oracle/jre/lib/endorsed" />
-    <property name="os.arch" value="amd64" />
-    <property name="java.io.tmpdir" value="/tmp" />
-    <property name="line.separator" value="&#xA;" />
-    <property name="java.vm.specification.vendor" value="Oracle Corporation" />
-    <property name="os.name" value="Linux" />
-    <property name="classworlds.conf" value="/usr/share/maven/bin/m2.conf" />
-    <property name="sun.jnu.encoding" value="UTF-8" />
-    <property name="java.library.path" value="/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib" />
-    <property name="java.specification.name" value="Java Platform API Specification" />
-    <property name="java.class.version" value="51.0" />
-    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers" />
-    <property name="os.version" value="3.13.0-74-generic" />
-    <property name="user.timezone" value="Europe/Madrid" />
-    <property name="java.awt.printerjob" value="sun.print.PSPrinterJob" />
-    <property name="file.encoding" value="UTF-8" />
-    <property name="java.specification.version" value="1.7" />
-    <property name="java.class.path" value="/usr/share/maven/boot/plexus-classworlds-2.x.jar" />
-    <property name="java.vm.specification.version" value="1.7" />
-    <property name="sun.arch.data.model" value="64" />
-    <property name="java.home" value="/usr/lib/jvm/java-7-oracle/jre" />
-    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher integration-test" />
-    <property name="java.specification.vendor" value="Oracle Corporation" />
-    <property name="user.language" value="en" />
-    <property name="awt.toolkit" value="sun.awt.X11.XToolkit" />
-    <property name="java.vm.info" value="mixed mode" />
-    <property name="java.version" value="1.7.0_80" />
-    <property name="java.ext.dirs" value="/usr/lib/jvm/java-7-oracle/jre/lib/ext:/usr/java/packages/lib/ext" />
-    <property name="securerandom.source" value="file:/dev/./urandom" />
-    <property name="sun.boot.class.path" value="/usr/lib/jvm/java-7-oracle/jre/lib/resources.jar:/usr/lib/jvm/java-7-oracle/jre/lib/rt.jar:/usr/lib/jvm/java-7-oracle/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jsse.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jce.jar:/usr/lib/jvm/java-7-oracle/jre/lib/charsets.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jfr.jar:/usr/lib/jvm/java-7-oracle/jre/classes" />
-    <property name="java.vendor" value="Oracle Corporation" />
-    <property name="maven.home" value="/usr/share/maven" />
-    <property name="file.separator" value="/" />
-    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/" />
-    <property name="sun.cpu.endian" value="little" />
-    <property name="sun.io.unicode.encoding" value="UnicodeLittle" />
-    <property name="sun.cpu.isalist" value="" />
+    <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+    <property name="sun.boot.library.path" value="/usr/lib/jvm/java-7-oracle/jre/lib/amd64"/>
+    <property name="java.vm.version" value="24.80-b11"/>
+    <property name="java.vm.vendor" value="Oracle Corporation"/>
+    <property name="java.vendor.url" value="http://java.oracle.com/"/>
+    <property name="path.separator" value=":"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="java.vm.name" value="Java HotSpot(TM) 64-Bit Server VM"/>
+    <property name="file.encoding.pkg" value="sun.io"/>
+    <property name="user.country" value="GB"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="sun.os.patch.level" value="unknown"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="java.runtime.version" value="1.7.0_80-b15"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.X11GraphicsEnvironment"/>
+    <property name="java.endorsed.dirs" value="/usr/lib/jvm/java-7-oracle/jre/lib/endorsed"/>
+    <property name="os.arch" value="amd64"/>
+    <property name="java.io.tmpdir" value="/tmp"/>
+    <property name="line.separator" value="&#10;"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="os.name" value="Linux"/>
+    <property name="classworlds.conf" value="/usr/share/maven/bin/m2.conf"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.library.path" value="/usr/java/packages/lib/amd64:/usr/lib64:/lib64:/lib:/usr/lib"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.class.version" value="51.0"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="3.13.0-74-generic"/>
+    <property name="user.timezone" value="Europe/Madrid"/>
+    <property name="java.awt.printerjob" value="sun.print.PSPrinterJob"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="java.specification.version" value="1.7"/>
+    <property name="java.class.path" value="/usr/share/maven/boot/plexus-classworlds-2.x.jar"/>
+    <property name="java.vm.specification.version" value="1.7"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="java.home" value="/usr/lib/jvm/java-7-oracle/jre"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher integration-test"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.language" value="en"/>
+    <property name="awt.toolkit" value="sun.awt.X11.XToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="1.7.0_80"/>
+    <property name="java.ext.dirs" value="/usr/lib/jvm/java-7-oracle/jre/lib/ext:/usr/java/packages/lib/ext"/>
+    <property name="securerandom.source" value="file:/dev/./urandom"/>
+    <property name="sun.boot.class.path" value="/usr/lib/jvm/java-7-oracle/jre/lib/resources.jar:/usr/lib/jvm/java-7-oracle/jre/lib/rt.jar:/usr/lib/jvm/java-7-oracle/jre/lib/sunrsasign.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jsse.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jce.jar:/usr/lib/jvm/java-7-oracle/jre/lib/charsets.jar:/usr/lib/jvm/java-7-oracle/jre/lib/jfr.jar:/usr/lib/jvm/java-7-oracle/jre/classes"/>
+    <property name="java.vendor" value="Oracle Corporation"/>
+    <property name="maven.home" value="/usr/share/maven"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeLittle"/>
+    <property name="sun.cpu.isalist" value=""/>
   </properties>
-  <testcase name="replacement [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.035" />
-  <testcase name="noStartDocument [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.001" />
-  <testcase name="badPath [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002" />
+  <testcase name="replacement [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.035"/>
+  <testcase name="noStartDocument [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.001"/>
+  <testcase name="badPath [Scala 2.11]" classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002"/>
   <testcase classname="com.stratio.mojo.scala.crossbuild.ArtifactIdRewriteRuleTest" time="0.002" name="noArtifactChange [Scala 2.11]" />
 </testsuite>


### PR DESCRIPTION
- JUnit XML reports were sometimes malformed (e.g. illegal characters embedded
  in attribute values, not using entities). This makes preserving format
  hard.
- We now use regex-based rewriting for JUnit reports, so now formatting
  is preserved.
- Got rid of woodstox and jdom2 dependencies.